### PR TITLE
Fix: Indirect modification of overloaded property 

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,8 +1,0 @@
-# Default ignored files
-/shelf/
-/workspace.xml
-# Datasource local storage ignored files
-/dataSources/
-/dataSources.local.xml
-# Editor-based HTTP Client requests
-/httpRequests/

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/src/Traits/HasEnergy.php
+++ b/src/Traits/HasEnergy.php
@@ -7,7 +7,7 @@ use Hacklabs\Trends\Jobs\EnergyDecay;
 use Hacklabs\Trends\Models\Energy;
 use Illuminate\Support\Facades\DB;
 
-trait HasEnergy 
+trait HasEnergy
 {
     public function addEnergy($amount = 1) {
         if(!$this->energy) {
@@ -33,8 +33,9 @@ trait HasEnergy
     }
 
     public function decayEnergy($amount) {
+    	$energisableAmount = $this->energy->amount;
         $this->energy()->update([
-            'amount' => $this->energy->amount -= $amount
+            'amount' => $energisableAmount - $amount
         ]);
     }
 


### PR DESCRIPTION
Due to how accessing model attributes is implemented in Eloquent, when you access energy->amount, a magic __get() method is called that returns a copy of that attribute's value. 

This causes the queued job to fail and throw an error with the message `ErrorException: Indirect modification of overloaded property `. 

I fixed it by storing the value in a temporary variable, and subtract the amount later. 