### PR TITLE
Allow 2 decimals for energy amount

### DIFF
--- a/migrations/2020_03_27_000001_create_energies_table.php
+++ b/migrations/2020_03_27_000001_create_energies_table.php
@@ -16,7 +16,7 @@ class CreateEnergiesTable extends Migration
         Schema::create('energies', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->morphs('energisable');
-            $table->float('amount', 8, 1);
+            $table->float('amount', 8, 2);
             $table->timestamps();
         });
     }


### PR DESCRIPTION
This PR fixes a rounding problem caused by having the `amount` column defined as float(8,1), where if decreasing the energy by 0.25 for instance, it will be persisted to the database as 0.20

Issue can be recreated in Tinker as follows:
```php
# Add energy of 1 to an energisable model
$hashtag->addEnergy(1);
$hashtag->energy->amount; // 1.0

# Decrease energy by 0.25
$hashtag->decayEnergy(0.25)
$hashtag->refresh(); 
$hashtag->energy->amount; // 8.0 instead of 0.75
```