### PR TITLE
Energy not decaying completely if the amount given was greater than 1

### DIFF
--- a/src/Traits/HasEnergy.php
+++ b/src/Traits/HasEnergy.php
@@ -18,9 +18,9 @@ trait HasEnergy
             $this->energy()->update([
                 'amount' => $entity->energy->amount += $amount
             ]);
-            EnergyDecay::dispatch($entity, 0.25)->delay(now()->addHours(config('trends.energy_decay')));
-            EnergyDecay::dispatch($entity, 0.45)->delay(now()->addHours(config('trends.energy_decay') * 2));
-            EnergyDecay::dispatch($entity, 0.30)->delay(now()->addHours(config('trends.energy_decay') * 3));
+            EnergyDecay::dispatch($entity, 0.25 * $amount)->delay(now()->addHours(config('trends.energy_decay')));
+            EnergyDecay::dispatch($entity, 0.45 * $amount)->delay(now()->addHours(config('trends.energy_decay') * 2));
+            EnergyDecay::dispatch($entity, 0.30 * $amount)->delay(now()->addHours(config('trends.energy_decay') * 3));
         }
     }
 


### PR DESCRIPTION
This PR fixes a problem where the dispatched jobs won't completely decay the energy back to 0 if the initial energy given was greater than 1.